### PR TITLE
Add Yubikey support for Flatpak build

### DIFF
--- a/org.pwsafe.pwsafe.yml
+++ b/org.pwsafe.pwsafe.yml
@@ -49,6 +49,42 @@ modules:
       - /lib/cmake
       - /share/doc/xerces-c
 
+  - name: libusb1
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+    sources:
+      - type: git
+        url: https://github.com/libusb/libusb.git
+        tag: v1.0.27
+        commit: d52e355daa09f17ce64819122cb067b8a2ee0d4b
+
+  - name: libyubikey
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-documentation
+    sources:
+      - type: git
+        url: https://github.com/Yubico/yubico-c.git
+        commit: e4334554857b0367085cbf845bf87dd92433e020
+      - type: shell
+        commands:
+          - autoreconf --install
+
+  - name: ykpers
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-documentation
+    sources:
+      - type: git
+        url: https://github.com/Yubico/yubikey-personalization.git
+        commit: db0c0d641d47ee52e43af94dcee603d76186b6d3
+      - type: shell
+        commands:
+          - autoreconf --install
+
   - name: pwsafe
     builddir: true
     buildsystem: cmake-ninja
@@ -60,4 +96,7 @@ modules:
         url: https://github.com/pwsafe/pwsafe/
         tag: 1.18.2fp4
         commit: 4062b9374538992883d7cde0da096f803ba2a835
-
+      - type: shell
+        commands:
+        # Put the ykpers headers where the build can find them
+        - mv /app/include/ykpers-1/* /app/include


### PR DESCRIPTION
This PR adds USB and Yubikey libraries to the Flatpak build.  It works in my environment, but really needs testing on other distros and HW platforms.  A couple things I'm not sure about:

- The inclusion of libusb1 in the build.  It's not included in the org.freedesktop.Platform, but is in the org.fedoraproject.Platform.  Libyubikey needed it to get through the configure step.  I don't know if there's a better way to deal with low-level libs that might be provided with the system.
- The mv command at the end, to move the yk* headers up one level, because I couldn't figure out how to pass  "-I/app/include/ykpers-1" option through the build systems.  (In native Linux builds, cmake adds "-I/usr/include/ykpers-1".)

Any tips, tricks, and general education are welcome!

Built and tested on Fedora 39 ARM running under VMware Fusion on macOS 14.4 M1max.