### PR TITLE
Restrict device premissions to USB instead of 'all'

### DIFF
--- a/org.pwsafe.pwsafe.yml
+++ b/org.pwsafe.pwsafe.yml
@@ -5,6 +5,7 @@ sdk: org.freedesktop.Sdk
 command: pwsafe
 rename-icon: pwsafe
 rename-desktop-file: pwsafe.desktop
+require-version: '1.10.0'
 finish-args:
   - --socket=fallback-x11
   - --socket=wayland

--- a/org.pwsafe.pwsafe.yml
+++ b/org.pwsafe.pwsafe.yml
@@ -11,8 +11,8 @@ finish-args:
   - --share=ipc
   - --filesystem=xdg-documents
   - --env=PWS_HELPDIR=/app/share/passwordsafe/help/
-  # YubiKey USB access
-  - --device=all
+  # YubiKey requires USB access
+  - --device=usb
 cleanup:
   - '/include'
 


### PR DESCRIPTION
USB is needed for Yubikey to function.