### PR TITLE
Fix pwsafe to be able to build under Freedesktop Runtime 25.08

### DIFF
--- a/org.pwsafe.pwsafe.yml
+++ b/org.pwsafe.pwsafe.yml
@@ -1,6 +1,6 @@
 app-id: org.pwsafe.pwsafe
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: pwsafe
 rename-icon: pwsafe
@@ -41,8 +41,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/apache/xerces-c
-        tag: v3.2.4
-        commit: 5052c90b067dcc347d58822b450897d16e2c31e5
+        tag: v3.3.0
+        commit: 31b4b3a06105dcd607db9fda9d1883ad7e489bfe
+      - type: patch
+        path: patches/xerces-c-cxx17.patch
     cleanup:
       - /lib/cmake
       - /share/doc/xerces-c

--- a/patches/xerces-c-cxx17.patch
+++ b/patches/xerces-c-cxx17.patch
@@ -1,0 +1,25 @@
+# patch from  https://bugs.gentoo.org/931105
+From de3ae3ded7a07de5afe63cb472ef423fac6225a4 Mon Sep 17 00:00:00 2001
+From: Kostadin Shishmanov <kocelfc@tutanota.com>
+Date: Thu, 2 May 2024 21:20:41 +0300
+Subject: [PATCH] c++17
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 33bc40f..133468f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,7 +23,7 @@ cmake_minimum_required(VERSION 3.12.0)
+ 
+ # Try C++14, then fall back to C++11 and C++98.  Used for feature tests
+ # for optional features.
+-set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
+ 
+ # Use folders (for IDE project grouping)
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+-- 
+2.43.2


### PR DESCRIPTION
Fix for [Upgrade flatpak Freedesktop SDK v23.08 to v24.08 #1482](https://github.com/pwsafe/pwsafe/issues/1482)
