### PR TITLE
Remove libusb since it's included in runtime 25.08

### DIFF
--- a/org.pwsafe.pwsafe.yml
+++ b/org.pwsafe.pwsafe.yml
@@ -49,16 +49,6 @@ modules:
       - /lib/cmake
       - /share/doc/xerces-c
 
-  - name: libusb1
-    buildsystem: autotools
-    config-opts:
-      - --disable-static
-    sources:
-      - type: git
-        url: https://github.com/libusb/libusb.git
-        tag: v1.0.27
-        commit: d52e355daa09f17ce64819122cb067b8a2ee0d4b
-
   - name: libyubikey
     buildsystem: autotools
     config-opts:


### PR DESCRIPTION
Resolves #22 

Builds fine and Yubukey works.  Built and tested on:
```
Fedora 43 ARM64 VMware,      KDE/Wayland,   gcc 15.2.1, wx 3.2.8, GTK 3.24.51
Ubuntu 24.04.3 ARM64 VMware, Gnome/Wayland, gcc 13.3.0, wx 3.2.4, GTK 3.24.41
Fedora 43 ARM64 VMware,      Xfce/X11,      gcc 15.2.1, wx 3.2.8, GTK 3.24.51

```